### PR TITLE
misspelled RCurl removed, pacman used, pack install reproducible

### DIFF
--- a/workshop_packages_to_install.R
+++ b/workshop_packages_to_install.R
@@ -1,24 +1,14 @@
 ###### CODE WORKING FOR R VERSION <= 3.6.3
 
-install.packages("yaml")
-install.packages("data.table")
-install.packages("stringr")
-install.packages("readr")
-install.packages("rCurl")
-install.packages("config")
-install.packages("ggthemes")
-install.packages("ggplot2")
-install.packages("prettydoc")
-install.packages("rmarkdown")
-install.packages("scales")
-install.packages("tidyverse")
-install.packages("dplyr")
-install.packages("kableExtra")
-install.packages("RCurl")
+install.packages("pacman")
+
+pacman::p_load("yaml","data.table","stringr","readr","config","ggthemes",
+               "ggplot2","prettydoc","rmarkdown","scales","tidyverse","dplyr",
+               "kableExtra","RCurl")
 
 ###### INSTALL PrescRiptions from source
 
-install.packages("~/PrescRiptions_0.2.5.tar.gz", repos = NULL, type = "source")
+install.packages("05_PrescRiptions_project/packages/PrescRiptions_0.2.5.tar.gz", repos = NULL, type = "source")
 
 
 


### PR DESCRIPTION
pacman installs the packages only if needed. Using the directory name allows easy installation of PrescRiptions after cloning the repo